### PR TITLE
Fix returning array of elements from device breakpoints

### DIFF
--- a/src/components/utils/DeviceUtils.tsx
+++ b/src/components/utils/DeviceUtils.tsx
@@ -19,6 +19,9 @@ const makeDevice = (breakpoint: Breakpoint, direction: BreakpointDirection) => {
       hidden = useMediaQuery<Theme>(theme => theme.breakpoints.down(breakpoint));
     }
     if (hidden) return null;
+    if (children instanceof Array) {
+      return <>{children}</>;
+    }
 
     return children;
   };


### PR DESCRIPTION
Previously, this would cause an error when used in `ModulesListPage` since it was returning an array of elements which was not allowed in that position.