### PR TITLE
Create URLParams wrapper to handle creations of url parameters better

### DIFF
--- a/src/api/raw/auth.ts
+++ b/src/api/raw/auth.ts
@@ -1,6 +1,6 @@
 import { IPersonalUser, IUser } from '~types';
 
-import { axios, BASE_URL } from '../utils';
+import { axios, BASE_URL, URLParams } from '../utils';
 import { ApiErrors, validateStatusCode } from './ApiErrors';
 
 const ACCOUNT_LOGIN_URL = `${BASE_URL}/account/login`;
@@ -13,7 +13,7 @@ const ACCOUNT_RESET_COMPLETE = `${BASE_URL}/account/resets/complete`;
 export const login = async (username: string, password: string): Promise<IUser> => {
   const response = await axios.post<IUser>(
     ACCOUNT_LOGIN_URL,
-    new URLSearchParams({ username, password }).toString(),
+    new URLParams({ username, password }).toString(),
   );
 
   return validateStatusCode(response, ApiErrors.Login);
@@ -32,7 +32,7 @@ export const createAccount = async (
 ): Promise<IUser> => {
   const response = await axios.post<IUser>(
     ACCOUNT_NEW_URL,
-    new URLSearchParams({ username, password, email }).toString(),
+    new URLParams({ username, password, email }).toString(),
   );
 
   return validateStatusCode(response, (): string | undefined => {
@@ -71,7 +71,7 @@ export const requestPasswordComplete = async (
 ): Promise<unknown> => {
   const response = await axios.post(
     ACCOUNT_RESET_COMPLETE,
-    new URLSearchParams({ password, token }).toString(),
+    new URLParams({ password, token }).toString(),
   );
 
   return validateStatusCode(response, ApiErrors.PasswordResetComplete);

--- a/src/api/raw/modules.ts
+++ b/src/api/raw/modules.ts
@@ -1,6 +1,6 @@
 import { IModule, IModuleResponse, ModuleSorting } from '~types';
 
-import { axios, BASE_URL } from '../utils';
+import { axios, BASE_URL, URLParams } from '../utils';
 import { ApiErrors, validateStatusCode } from './ApiErrors';
 
 const MODULES_URL = `${BASE_URL}/modules`;
@@ -40,18 +40,15 @@ export const createModule = async (
   image?: string,
   flagged = false,
 ): Promise<IModule> => {
-  const paramsObj: Partial<IModule> = {
+  const searchParams = new URLParams({
     name,
     description,
-    tags,
     flagged,
-  };
-  if (image) paramsObj.image = image;
+    image,
+    tags,
+  });
 
-  const response = await axios.post<IModule>(
-    MODULES_URL,
-    new URLSearchParams(paramsObj as any).toString(),
-  );
+  const response = await axios.post<IModule>(MODULES_URL, searchParams.toString());
 
   return validateStatusCode(response);
 };
@@ -68,16 +65,11 @@ export const updateModule = async (
   flagged?: boolean,
   tags?: string[],
 ): Promise<IModule> => {
-  const query: Partial<IModule> = {};
+  const searchParams = new URLParams({ description, image, flagged, tags });
 
-  if (description) query.description = description;
-  if (image) query.image = image;
-  if (flagged !== undefined) query.flagged = flagged;
-  if (tags) query.tags = tags;
   const response = await axios.patch<IModule>(
     moduleIdUrl(moduleId),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    new URLSearchParams(query as any).toString(),
+    searchParams.toString(),
   );
 
   return validateStatusCode(response, ApiErrors.UpdateModule);

--- a/src/api/raw/releases.ts
+++ b/src/api/raw/releases.ts
@@ -2,7 +2,7 @@ import FormData from 'form-data';
 
 import { IRelease } from '~types';
 
-import { axios, BASE_URL } from '../utils';
+import { axios, BASE_URL, URLParams } from '../utils';
 import { ApiErrors, validateStatusCode } from './ApiErrors';
 
 const releasesUrl = (moduleId: string) => `${BASE_URL}/modules/${moduleId}/releases`;
@@ -73,14 +73,11 @@ export const updateRelease = async (
   modVersion?: string,
   changelog?: string,
 ): Promise<undefined> => {
-  const paramsObj: Record<string, string> = {};
-  if (modVersion) paramsObj.modVersion = modVersion;
-  if (changelog) paramsObj.changelog = changelog;
+  const searchParams = new URLParams({ modVersion, changelog });
 
-  const params = new URLSearchParams(paramsObj).toString();
   const response = await axios.patch<undefined>(
     releasesUrlSpecific(moduleId.toString(), releaseId),
-    params,
+    searchParams.toString(),
   );
 
   return validateStatusCode(response, ApiErrors.UpdateRelease);

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -10,3 +10,51 @@ export const axios = Axios.create({
   withCredentials: true,
   timeout: 60000,
 });
+
+export class URLParams {
+  inner: URLSearchParams;
+
+  constructor(obj: Record<string, unknown>) {
+    const inner = new URLSearchParams();
+    for (const property in obj) {
+      switch (typeof obj[property]) {
+        case 'string':
+          inner.append(property, obj[property] as string);
+          break;
+        case 'bigint':
+          inner.append(property, (obj[property] as bigint).toString());
+          break;
+        case 'boolean':
+          inner.append(property, (obj[property] as boolean).toString());
+          break;
+        case 'function':
+          throw new Error('Cannot add function to url parameters');
+        case 'number':
+          inner.append(property, (obj[property] as number).toString());
+          break;
+        case 'object':
+          if (Array.isArray(obj[property])) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (obj[property] as any[]).forEach(e => inner.append(property, e.toString()));
+          } else {
+            inner.append(property, JSON.stringify(obj[property] as object));
+          }
+          break;
+        case 'symbol':
+          {
+            const description = (obj[property] as symbol).description;
+            if (!description) throw new Error('Invalid symbol');
+            inner.append(property, description);
+          }
+          break;
+        case 'undefined':
+          break;
+      }
+    }
+    this.inner = inner;
+  }
+
+  toString(): string {
+    return this.inner.toString();
+  }
+}


### PR DESCRIPTION
Previously, objects that were arrays or undefined would cause issues when being used with `URLSearchParams`, this wrapper handles these cases to ensure the requests are correctly formed.